### PR TITLE
 Comentada línea sqlalchemy.url porque la conexión ahora se gestiona desde el archivo .env

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -61,7 +61,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = driver://user:pass@localhost/dbname
+#sqlalchemy.url = driver://user:pass@localhost/dbname 
 
 
 [post_write_hooks]

--- a/main.py
+++ b/main.py
@@ -1,9 +1,29 @@
 
 from fastapi import FastAPI
+from fastapi import Depends, Query
+from sqlalchemy.orm import Session
+from app.database import SessionLocal
 
-# Initialize FastAPI app
+from fastapi.middleware.cors import CORSMiddleware
+#from app.controllers.tu_jemplo_controller import get_all_funciónEjemplo     #Aquí importarás las funciones desde tus controllers
+#from app.routes.tu_ejemplo_router import router as ejemplo_router           #Aquí importarás tus rutas desde tus archivos router
+
+# Inicializa FastAPI app
 app = FastAPI()
+
+# Configuración CORS 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Permite cualquier origen (en producción, especificar dominios permitidos)
+    allow_credentials=True,
+    allow_methods=["*"],   # Permite todos los métodos (GET, POST, PUT, DELETE, etc.)
+    allow_headers=["*"],   # Permite todos los encabezados 
+)
+
+#
+#app.include_router(ejemplo_router)  #Incluye tus routers en este espacio
+#
 
 @app.get("/")
 def read_root():
-    return {"message": "Checka estooooo!"}
+    return {"message": "Bienvenido a tu nueva API!"}


### PR DESCRIPTION
La línea original `sqlalchemy.url = driver://user:pass@localhost/dbname` ha sido comentada porque 
la configuración de conexión a la base de datos ahora se realiza dinámicamente desde el archivo 
`.env`, utilizando `config.py` y `database.py` en el proyecto. Esto evita mantener credenciales en 
archivos de configuración estáticos y permite mayor flexibilidad y seguridad al usar entornos de 
desarrollo y producción distintos.

Alembic seguirá funcionando correctamente porque la URL se cargará desde `app/config.py` en tiempo 
de ejecución, siempre que `env.py` esté correctamente configurado.